### PR TITLE
Range-based generation fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<repositories>
 		<repository>
 			<id>rubygems-releases</id>
-			<url>http://gems.saumya.de/releases</url>
+			<url>http://rubygems-proxy.torquebox.org/releases</url>
 		</repository>
 	</repositories>
 

--- a/spec/regex_gen_spec.rb
+++ b/spec/regex_gen_spec.rb
@@ -34,6 +34,10 @@ describe RegexGen do
       RegexGen.of("[a-f]{3}").should match("^[a-f]{3}$")
     end
 
+    it "should return exact number of requested characters in range" do
+      RegexGen.of("[a-c]{100}").should match("^[a-c]{100}$")
+    end
+
     it "should return value from both character set and range" do
       RegexGen.of("[0-9HAL]{3}").should match("^[0-9HAL]{3}$")
       RegexGen.of("[HAL0-9]{3}").should match("^[HAL0-9]{3}$")

--- a/src/main/java/br/com/six2six/bfgex/interpreter/Sexp.java
+++ b/src/main/java/br/com/six2six/bfgex/interpreter/Sexp.java
@@ -76,7 +76,7 @@ public class Sexp {
         	result = reduce(expressions, quantity);
         	break;
         case CHARCLASS:
-            result = genValue(StringUtils.join(mapReduce(expressions), "").split(""), quantity == null ? new Quantifier(1) : quantity);
+            result = genValue(StringUtils.join(mapReduce(expressions), "").split("(?!^)"), quantity == null ? new Quantifier(1) : quantity);
             break;
         case RANGE:
             result = buildCharset(mapReduce(expressions));


### PR DESCRIPTION
String.split("") returns leading empty string ("abc" will be splitted into "", "a", "b", "c"). Generator later treats empty string as valid character and this causes string to be returned not the same length as expected.
I've also updated ruby gems repo because http://gems.saumya.de/releases is dead.
